### PR TITLE
Adds missing return directive to AbstractFactory

### DIFF
--- a/src/ServiceFactory/AbstractCqrsServiceFactory.php
+++ b/src/ServiceFactory/AbstractCqrsServiceFactory.php
@@ -21,7 +21,7 @@ class AbstractCqrsServiceFactory implements AbstractFactoryInterface
 
     public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
-        $this($serviceLocator, $requestedName);
+        return $this($serviceLocator, $requestedName);
     }
 
     /**


### PR DESCRIPTION
For zf 2.x this `return` directive is MUST have. With out it nothing is working.